### PR TITLE
Remove empty results check from WordPress docs search

### DIFF
--- a/packages/mcp-wordpress-docs/src/index.ts
+++ b/packages/mcp-wordpress-docs/src/index.ts
@@ -400,17 +400,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       const results = await searchWordPressDocs(query, subtypes, perPage);
 
-      if (results.length === 0) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "No results found. Please try a different keyword.",
-            },
-          ],
-        };
-      }
-
       return {
         content: [
           {


### PR DESCRIPTION
fix: #5

## Summary
Removed the early return condition that checked for empty search results in the WordPress documentation search tool. The search endpoint will now return results regardless of whether matches are found, allowing the response handling to be managed consistently.

## Changes
- Removed the empty results validation check that returned a "No results found" message
- The search function now returns its results directly without intermediate filtering
- Response handling is now uniform for all search queries, whether they return matches or not

## Details
This change simplifies the search tool's response logic by eliminating a special case for empty result sets. The downstream response will now contain the actual search results (which may be an empty array) rather than a predefined message, giving callers more flexibility in how they handle and present search outcomes.
